### PR TITLE
fix: search and correct send types finally (based on file ext)

### DIFF
--- a/app/src/features/chats/hooks/useChatInput.ts
+++ b/app/src/features/chats/hooks/useChatInput.ts
@@ -27,12 +27,13 @@ function useChatInput() {
     handleSendMessage("", chatId, sticker, "sticker");
     setIsEmojiSelectorOpen(false);
   };
-  const handleSubmit = (e: Event, voiceNoteName = "") => {
+
+  const handleSubmit = (e: Event, voiceNoteName = "voice") => {
     console.log(voiceNoteName);
     e.preventDefault();
     setIsEmojiSelectorOpen(false);
     if (isRecording !== "idle") return;
-    handleSendMessage(input, chatId, voiceNoteName, "audio");
+    handleSendMessage(input, chatId);
     dispatch(clearActiveMessage());
     setInput("");
   };

--- a/app/src/features/chats/hooks/useMessageSender.ts
+++ b/app/src/features/chats/hooks/useMessageSender.ts
@@ -3,6 +3,7 @@ import { ContentType, MessageInterface, MessageStatus } from "types/messages";
 import { useSocket } from "@hooks/useSocket";
 import { useEncryptDecrypt } from "./useEncryptDecrypt";
 import { getChatByID } from "../utils/helpers";
+import { getFileType } from "@utils/helpers";
 
 export const useMessageSender = () => {
   const { sendMessage, editMessage } = useSocket();
@@ -17,14 +18,14 @@ export const useMessageSender = () => {
     data: string,
     chatId?: string,
     file?: string,
-    type: ContentType = "text",
+    type: ContentType = "text"
   ) => {
     const chat = getChatByID({ chats, chatID: chatId as string });
 
     const encrypedMessage = await encrypt({
       message: data,
-      key: chat?.encryptionKey!,
-      iv: chat?.initializationVector!,
+      key: chat?.encryptionKey as string,
+      iv: chat?.initializationVector as string
     });
 
     if (activeMessage?.id && activeMessage.state === "edit") {
@@ -34,7 +35,9 @@ export const useMessageSender = () => {
 
     const isReply = activeMessage.state === "reply";
     const isEncryptedContent =
-      chat?.type! === "private" && typeof encrypedMessage === "string";
+      chat?.type === "private" && typeof encrypedMessage === "string";
+
+    type = getFileType(file, isEncryptedContent ? encrypedMessage : data);
 
     if (encrypedMessage || file) {
       const message: MessageInterface = {
@@ -45,26 +48,26 @@ export const useMessageSender = () => {
         isPinned: false,
         isForward: false,
         isAnnouncement: false,
+        isAppropriate: false,
         senderId: userId,
         chatId: chatId!,
-
         parentMessageId: isReply ? activeMessage.id : null,
         isReply,
         status: MessageStatus.sent,
         media: file,
-        threadMessages: [],
+        threadMessages: []
       };
 
       const threadMessage = {
         ...message,
         parentMessageId: activeThread,
         isReply: true,
-        chatType: "channel",
+        chatType: "channel"
       };
 
       const messageToSend = activeThread ? threadMessage : message;
 
-      sendMessage({ ...messageToSend, chatType: chat?.type! });
+      sendMessage({ ...messageToSend, chatType: chat?.type || "private" });
     }
   };
 

--- a/app/src/features/search/components/SearchTab.tsx
+++ b/app/src/features/search/components/SearchTab.tsx
@@ -89,6 +89,7 @@ const SearchTab: React.FC = () => {
             image={group?.photo}
             username={group?.name}
             subscribers={group?.numberOfMembers}
+            chatId={group?.id}
           />
         )
       )}
@@ -104,6 +105,7 @@ const SearchTab: React.FC = () => {
             image={channel?.photo}
             username={channel?.name}
             subscribers={channel?.numberOfMembers}
+            chatId={channel?.id}
           />
         )
       )}

--- a/app/src/features/search/components/result-items/ChannelResult.tsx
+++ b/app/src/features/search/components/result-items/ChannelResult.tsx
@@ -54,7 +54,7 @@ const ChannelResult: React.FC<ChannelResultProps> = ({
   image,
   username,
   subscribers,
-  chatId,
+  chatId
 }) => {
   const navigate = useNavigate();
   const handleItemClick = () => {

--- a/app/src/utils/helpers.ts
+++ b/app/src/utils/helpers.ts
@@ -38,4 +38,43 @@ function isValidDate(date: string): boolean {
   return new Date(date).toString() !== "Invalid Date";
 }
 
-export { getElapsedTime, getAvatarName, isValidDate };
+export type SearchFilter =
+  | "text"
+  | "image"
+  | "GIF"
+  | "sticker"
+  | "audio"
+  | "video"
+  | "file"
+  | "link";
+
+function getFileType(filename?: string, content?: string): SearchFilter {
+  if (content === undefined) return "text";
+
+  const urlPattern = /(https?:\/\/)/i;
+  if (urlPattern.test(content)) return "link";
+
+  if (!filename) return "text";
+
+  const ext = filename.toLowerCase().split(".").pop() || "";
+
+  const imageExts = ["jpg", "jpeg", "png", "webp", "svg", "bmp"];
+  if (imageExts.includes(ext)) return "image";
+
+  if (ext === "gif") return "GIF";
+
+  const stickerExts = ["webp", "apng"];
+  if (stickerExts.includes(ext)) return "sticker";
+
+  const audioExts = ["mp3", "wav", "ogg", "m4a", "aac", "webm"];
+  if (audioExts.includes(ext)) return "audio";
+
+  const videoExts = ["mp4", "mov", "avi", "mkv"];
+  if (videoExts.includes(ext)) return "video";
+
+  if (ext) return "file";
+
+  return "text";
+}
+
+export { getElapsedTime, getAvatarName, isValidDate, getFileType };


### PR DESCRIPTION
This pull request includes several changes to improve the handling of message types and enhance the search functionality in the chat application. The most important changes involve modifying the `useMessageSender` hook to determine the file type dynamically, updating the `SearchTab` component to include chat IDs, and adding a new utility function to identify file types.
